### PR TITLE
Enhanced Photo Gallery Navigation and Message Integration

### DIFF
--- a/lib/components/app_drawer.dart
+++ b/lib/components/app_drawer.dart
@@ -4,6 +4,7 @@ import './gallery/photo_handler.dart';
 import './ui_utils/theme_manager.dart';
 import './profile_photo/profile_photo.dart';
 import './search/cross_collection_search.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class AppDrawer extends StatelessWidget {
   final String? selectedCollection;
@@ -20,6 +21,8 @@ class AppDrawer extends StatelessWidget {
   final ImagePicker picker;
   final Function(List<dynamic>) onCrossCollectionSearch;
   final VoidCallback onDrawerClosed;
+  final List<Map<dynamic, dynamic>> messages;
+  final ItemScrollController itemScrollController;
 
   const AppDrawer({
     super.key,
@@ -37,6 +40,8 @@ class AppDrawer extends StatelessWidget {
     required this.picker,
     required this.onCrossCollectionSearch,
     required this.onDrawerClosed,
+    required this.messages,
+    required this.itemScrollController,
   });
 
   @override
@@ -100,6 +105,8 @@ class AppDrawer extends StatelessWidget {
                       PhotoHandler.handleShowAllPhotos(
                         context,
                         selectedCollection,
+                        messages: messages,
+                        itemScrollController: itemScrollController,
                       );
                     },
                   ),

--- a/lib/components/gallery/photo_handler.dart
+++ b/lib/components/gallery/photo_handler.dart
@@ -4,6 +4,7 @@ import '../../utils/api_db/api_service.dart';
 import 'photo_gallery.dart';
 import 'dart:convert';
 import 'package:logging/logging.dart';
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 
 class PhotoHandler {
   static final Logger _logger = Logger('PhotoHandler');
@@ -13,13 +14,21 @@ class PhotoHandler {
   static String? imageUrl;
 
   static void handleShowAllPhotos(
-      BuildContext context, String? selectedCollection) {
+    BuildContext context,
+    String? selectedCollection, {
+    List<Map<dynamic, dynamic>>? messages = const [],
+    ItemScrollController? itemScrollController,
+  }) {
     if (selectedCollection == null) return;
 
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => PhotoGallery(collectionName: selectedCollection),
+        builder: (context) => PhotoGallery(
+          collectionName: selectedCollection,
+          messages: messages ?? [],
+          itemScrollController: itemScrollController ?? ItemScrollController(),
+        ),
       ),
     );
   }

--- a/lib/components/gallery/photo_view_gallery.dart
+++ b/lib/components/gallery/photo_view_gallery.dart
@@ -8,17 +8,21 @@ import 'package:flutter/services.dart';
 class PhotoViewGalleryScreen extends StatefulWidget {
   final List<Map<String, dynamic>> photos;
   final int initialIndex;
-  final Function(Map<String, dynamic>) onLongPress;
+  final Function(Map<String, dynamic>)? onLongPress;
   final String collectionName;
   final bool showAppBar;
+  final Function(int)? onJumpToGallery;
+  final Function(Map<String, dynamic>)? onJumpToMessage;
 
   const PhotoViewGalleryScreen({
     super.key,
     required this.photos,
     required this.initialIndex,
-    required this.onLongPress,
+    this.onLongPress,
     required this.collectionName,
     this.showAppBar = true,
+    this.onJumpToGallery,
+    this.onJumpToMessage,
   });
 
   @override
@@ -82,7 +86,9 @@ class _PhotoViewGalleryScreenState extends State<PhotoViewGalleryScreen> {
       onKeyEvent: _handleKeyEvent,
       autofocus: true,
       child: GestureDetector(
-        onLongPress: () => widget.onLongPress(widget.photos[_currentIndex]),
+        onLongPress: widget.onLongPress != null
+            ? () => widget.onLongPress!(widget.photos[_currentIndex])
+            : null,
         child: Scaffold(
           backgroundColor: Colors.black,
           appBar: widget.showAppBar
@@ -90,6 +96,13 @@ class _PhotoViewGalleryScreenState extends State<PhotoViewGalleryScreen> {
                   backgroundColor: Colors.black.withOpacity(0.5),
                   title: Text('${_currentIndex + 1} / ${widget.photos.length}'),
                   actions: [
+                    if (widget.onJumpToGallery != null)
+                      IconButton(
+                        icon: const Icon(Icons.grid_view),
+                        onPressed: () =>
+                            widget.onJumpToGallery?.call(_currentIndex),
+                        tooltip: 'Jump to Gallery',
+                      ),
                     IconButton(
                       icon: const Icon(Icons.download),
                       onPressed: () => _downloadCurrentImage(),

--- a/lib/components/messages/message_index_manager.dart
+++ b/lib/components/messages/message_index_manager.dart
@@ -35,7 +35,11 @@ class MessageIndexManager {
     }
   }
 
-  int? getIndexForTimestamp(int timestamp, {bool isPhotoTimestamp = false}) {
+  int? getIndexForTimestamp(
+    int timestamp, {
+    bool isPhotoTimestamp = false,
+    bool useCreationTimestamp = false,
+  }) {
     if (_sortedMessages == null || _sortedMessages!.isEmpty) {
       return null;
     }

--- a/lib/components/messages/message_item.dart
+++ b/lib/components/messages/message_item.dart
@@ -9,6 +9,7 @@ import '../search/search_type.dart';
 import '../search/scroll_to_highlighted_message.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import '../messages/message_index_manager.dart';
+import '../gallery/photo_gallery.dart';
 
 class MessageItem extends StatefulWidget {
   final Map<String, dynamic> message;
@@ -104,10 +105,7 @@ class MessageItemState extends State<MessageItem> {
     final manager = MessageIndexManager();
     manager.updateMessages(widget.messages);
 
-    // Get all photos from all messages to enable swiping through the entire collection
     final allPhotos = manager.allPhotos;
-
-    // Find the starting index in the full collection
     final startingPhoto = photos[index];
     final startingIndex = allPhotos.indexWhere((photo) =>
         photo['uri'] == startingPhoto['uri'] &&
@@ -117,8 +115,7 @@ class MessageItemState extends State<MessageItem> {
       context,
       MaterialPageRoute(
         builder: (context) => PhotoViewGalleryScreen(
-          photos:
-              allPhotos, // Use all photos instead of just this message's photos
+          photos: allPhotos,
           initialIndex: startingIndex >= 0 ? startingIndex : 0,
           onLongPress: (currentPhoto) {
             Navigator.pop(context);
@@ -135,6 +132,19 @@ class MessageItemState extends State<MessageItem> {
                 SearchType.photoView,
               );
             }
+          },
+          onJumpToGallery: (currentIndex) {
+            Navigator.pop(context);
+            final currentPhoto = allPhotos[currentIndex];
+            PhotoGalleryState.navigateToGalleryAndScroll(
+              context,
+              widget.isCrossCollectionSearch
+                  ? widget.message['collectionName']
+                  : widget.selectedCollectionName,
+              currentPhoto,
+              widget.messages,
+              widget.itemScrollController,
+            );
           },
           collectionName: widget.isCrossCollectionSearch
               ? widget.message['collectionName']

--- a/lib/components/messages/message_selector.dart
+++ b/lib/components/messages/message_selector.dart
@@ -359,6 +359,8 @@ class MessageSelectorState extends State<MessageSelector> {
         picker: picker,
         onCrossCollectionSearch: _handleCrossCollectionSearch,
         onDrawerClosed: () => _setVisibilityState(VisibilityState.none),
+        messages: messages.map((m) => Map<String, dynamic>.from(m)).toList(),
+        itemScrollController: itemScrollController,
       ),
       body: Stack(
         children: [

--- a/lib/components/search/search_messages.dart
+++ b/lib/components/search/search_messages.dart
@@ -7,18 +7,41 @@ Future<List<int>> _computeSearchResults(List<dynamic> params) async {
   final List<dynamic> messages = params[1];
 
   final normalizedQuery = removeDiacritics(query.toLowerCase());
+
+  if (normalizedQuery == "photo") {
+    // Debug: Print total messages and photos found
+    int totalPhotos = 0;
+    List<int> photoIndices = [];
+
+    for (int i = 0; i < messages.length; i++) {
+      final message = messages[i];
+      final senderName = message['sender_name']?.toString().toLowerCase() ?? '';
+      final hasPhotos =
+          message['photos'] != null && (message['photos'] as List).isNotEmpty;
+
+      if (hasPhotos && senderName != "tadeáš fořt") {
+        totalPhotos += (message['photos'] as List).length;
+        photoIndices.add(i);
+      }
+    }
+
+    if (kDebugMode) {
+      print('Total messages: ${messages.length}');
+    }
+    if (kDebugMode) {
+      print('Total photo messages found: ${photoIndices.length}');
+    }
+    if (kDebugMode) {
+      print('Total photos count: $totalPhotos');
+    }
+
+    return photoIndices;
+  }
+
   return List<int>.generate(messages.length, (i) {
     final message = messages[i];
     final content = message['content']?.toString().toLowerCase() ?? '';
     final senderName = message['sender_name']?.toString().toLowerCase() ?? '';
-
-    if (normalizedQuery == "photo") {
-      return (message['photos'] != null &&
-              (message['photos'] as List).isNotEmpty &&
-              senderName != "tadeáš fořt")
-          ? i
-          : -1;
-    }
 
     return (removeDiacritics(content).contains(normalizedQuery) ||
             removeDiacritics(senderName).contains(normalizedQuery))

--- a/lib/components/search/search_type.dart
+++ b/lib/components/search/search_type.dart
@@ -1,1 +1,1 @@
-enum SearchType { searchWidget, photoView, crossCollection }
+enum SearchType { searchWidget, photoView, crossCollection, galleryGrid }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,7 +15,9 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 // by showing a list similarly as in collection widget sorted DESC according to number of messages containing
 // searched string
 
-// TODO: include long press photo to scroll to highlighted photo message in gallery photo view component as well
+// TODO: in message list view, fix the photo preview - we are now not respecting the photo dimensions
+// and it looks weird
+
 void main() async {
   await dotenv.load(fileName: ".env");
   runApp(MyApp());


### PR DESCRIPTION
This update improves how users interact with photos throughout the app
by adding seamless navigation between different photo views and
messages:

- Added ability to jump directly from a photo to its original message
context
- Implemented a new gallery grid view button in the photo viewer
- Added smooth scrolling to specific photos in the gallery grid
- Improved photo navigation when viewing photos from search results

These changes make it easier for users to find the context of any photo
and move naturally between different ways of viewing photos in the app.
Whether you're browsing the gallery or viewing individual photos, you
can now quickly find related messages and switch between viewing modes.